### PR TITLE
refactor(online-offline): replace Skia with native grayscale filter

### DIFF
--- a/src/animations/online-offline/components/online-to-offline/index.tsx
+++ b/src/animations/online-offline/components/online-to-offline/index.tsx
@@ -77,6 +77,7 @@ export const OnlineToOffline = ({
             itemSize={itemSize}
             listColor={listColor}
             isOffline={item.isOffline}
+            zIndex={listItems.length - index}
           />
         ))}
       </Animated.View>

--- a/src/animations/online-offline/components/online-to-offline/list-item.tsx
+++ b/src/animations/online-offline/components/online-to-offline/list-item.tsx
@@ -2,16 +2,9 @@ import { StyleSheet } from 'react-native';
 
 import { memo } from 'react';
 
-import {
-  Canvas,
-  ColorMatrix,
-  Group,
-  Image,
-  useImage,
-} from '@shopify/react-native-skia';
 import Animated, {
   Easing,
-  interpolate,
+  useAnimatedStyle,
   useDerivedValue,
   withTiming,
 } from 'react-native-reanimated';
@@ -20,24 +13,15 @@ import { LayoutTransition } from './animations';
 
 import type { ItemProps } from './types';
 
-/**
- * Note on implementation choice:
- *
- * Using Skia for rendering images requires multiple canvases, which isn't ideal for performance.
- * A more practical approach would be to use expo-image with a native grayscale filter
- * (e.g., react-native-color-matrix-image-filters).
- *
- * However, this Skia approach provides smooth color interpolation during the online/offline
- * transition, which creates a better visual effect. Since this component is optimized for
- * development with Expo Go, Skia was chosen for its compatibility and ease of testing.
- *
- * For production apps, consider switching to expo-image for better performance.
- */
-
 export const ListItem = memo(
-  ({ item, leftPosition, itemSize, listColor, isOffline }: ItemProps) => {
-    const image = useImage(item);
-
+  ({
+    item,
+    leftPosition,
+    itemSize,
+    listColor,
+    isOffline,
+    zIndex,
+  }: ItemProps) => {
     const grayscaleProgress = useDerivedValue(() => {
       return withTiming(isOffline ? 1 : 0, {
         duration: 300,
@@ -45,34 +29,11 @@ export const ListItem = memo(
       });
     }, [isOffline]);
 
-    // Create animated color matrix
-    const animatedColorMatrix = useDerivedValue(() => {
-      const progress = grayscaleProgress.value;
-
-      // Identity matrix (no filter)
-      // prettier-ignore
-      const identityMatrix = [
-        1, 0, 0, 0, 0, // red channel
-        0, 1, 0, 0, 0, // green channel
-        0, 0, 1, 0, 0, // blue channel
-        0, 0, 0, 1, 0, // alpha channel
-      ];
-
-      // Grayscale matrix
-      // prettier-ignore
-      const grayscaleMatrix = [
-        0, 1, 0, 0, 0, // red channel
-        0, 1, 0, 0, 0, // green channel
-        0, 1, 0, 0, 0, // blue channel
-        0, 0, 0, 1, 0, // alpha channel
-      ];
-
-      // Interpolate between identity and grayscale matrices
-      return identityMatrix.map((identityValue, index) => {
-        const grayscaleValue = grayscaleMatrix[index];
-        return interpolate(progress, [0, 1], [identityValue, grayscaleValue]);
-      });
-    }, [grayscaleProgress]);
+    const animatedStyle = useAnimatedStyle(() => {
+      return {
+        filter: [{ grayscale: grayscaleProgress.value }],
+      };
+    });
 
     return (
       <Animated.View
@@ -87,34 +48,26 @@ export const ListItem = memo(
             borderRadius: itemSize / 2,
             borderColor: listColor,
             borderCurve: 'continuous',
+            zIndex,
           },
         ]}>
-        {image && (
-          <Canvas style={styles.canvas}>
-            <Group>
-              <Image
-                image={image}
-                x={0}
-                y={0}
-                width={itemSize}
-                height={itemSize}
-                fit="cover">
-                <ColorMatrix matrix={animatedColorMatrix} />
-              </Image>
-            </Group>
-          </Canvas>
-        )}
+        <Animated.Image
+          source={{ uri: item }}
+          style={[styles.image, animatedStyle]}
+          resizeMode="cover"
+        />
       </Animated.View>
     );
   },
 );
 
 const styles = StyleSheet.create({
-  canvas: {
+  image: {
     height: '100%',
     width: '100%',
   },
   item: {
+    backgroundColor: '#fff',
     borderWidth: 3,
     overflow: 'hidden',
     position: 'absolute',

--- a/src/animations/online-offline/components/online-to-offline/list-item.tsx
+++ b/src/animations/online-offline/components/online-to-offline/list-item.tsx
@@ -31,7 +31,7 @@ export const ListItem = memo(
 
     const animatedStyle = useAnimatedStyle(() => {
       return {
-        filter: `blur(${grayscaleProgress.value}px) grayscale(${grayscaleProgress.value})`,
+        filter: `grayscale(${grayscaleProgress.value})`,
       };
     });
 
@@ -68,7 +68,6 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   item: {
-    backgroundColor: '#fff',
     borderWidth: 3,
     overflow: 'hidden',
     position: 'absolute',

--- a/src/animations/online-offline/components/online-to-offline/list-item.tsx
+++ b/src/animations/online-offline/components/online-to-offline/list-item.tsx
@@ -31,7 +31,7 @@ export const ListItem = memo(
 
     const animatedStyle = useAnimatedStyle(() => {
       return {
-        filter: `grayscale(${grayscaleProgress.value})`,
+        filter: `blur(${grayscaleProgress.value}px) grayscale(${grayscaleProgress.value})`,
       };
     });
 

--- a/src/animations/online-offline/components/online-to-offline/list-item.tsx
+++ b/src/animations/online-offline/components/online-to-offline/list-item.tsx
@@ -31,7 +31,7 @@ export const ListItem = memo(
 
     const animatedStyle = useAnimatedStyle(() => {
       return {
-        filter: [{ grayscale: grayscaleProgress.value }],
+        filter: `grayscale(${grayscaleProgress.value})`,
       };
     });
 
@@ -53,7 +53,8 @@ export const ListItem = memo(
         ]}>
         <Animated.Image
           source={{ uri: item }}
-          style={[styles.image, animatedStyle]}
+          // @@TODO: check react native styles for this
+          style={[styles.image, animatedStyle as any]}
           resizeMode="cover"
         />
       </Animated.View>

--- a/src/animations/online-offline/components/online-to-offline/types.ts
+++ b/src/animations/online-offline/components/online-to-offline/types.ts
@@ -34,4 +34,5 @@ export type ItemProps = {
   itemSize: number;
   listColor: string;
   isOffline: boolean;
+  zIndex: number;
 };


### PR DESCRIPTION
## Summary
- Replace Skia's ColorMatrix grayscale implementation with native CSS-like `filter: grayscale()` on `Animated.Image`
- Add `zIndex` prop to `ListItem` for proper stacking order when items overlap
- Remove `@shopify/react-native-skia` dependency from this component

## Test plan
- [ ] Verify grayscale animation works when toggling online/offline state
- [ ] Confirm images stack correctly (no z-index artifacts)
- [ ] Test on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)