### PR TITLE
perf(scrollable-shapes): optimize rendering with drawPoints API

### DIFF
--- a/src/animations/scrollable-shapes/index.tsx
+++ b/src/animations/scrollable-shapes/index.tsx
@@ -138,12 +138,12 @@ const ScrollableShapes = () => {
 
     // Original used radius = Math.max(0.2, 0.5 * scale), so stroke width ~0.4-1.0
     if (farPoints.length > 0) {
-      paint.setStrokeWidth(0.6);
+      paint.setStrokeWidth(0.9);
       canvas.drawPoints(PointMode.Points, farPoints, paint);
     }
 
     if (midPoints.length > 0) {
-      paint.setStrokeWidth(0.8);
+      paint.setStrokeWidth(0.9);
       canvas.drawPoints(PointMode.Points, midPoints, paint);
     }
 


### PR DESCRIPTION
## Summary
- Replace `usePathValue` with `useDerivedValue` + `Picture` for GPU caching
- Use Skia's `drawPoints` API instead of 3000 individual `addCircle` calls
- Pre-compute rotation values and inline math to reduce per-point overhead
- Bin points by depth (3 levels) for perspective sizing with batch rendering

## Test plan
- [ ] Verify scrollable-shapes animation renders correctly
- [ ] Confirm smooth 60fps during shape morphing and rotation
- [ ] Test scroll gestures between all 4 shapes (sphere, cube, torus, heart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)