### PR TITLE
fix(art-gallery): keep iOS 26 menu from summoning the keyboard

### DIFF
--- a/src/animations/art-gallery/index.tsx
+++ b/src/animations/art-gallery/index.tsx
@@ -6,7 +6,14 @@ import {
   View,
 } from 'react-native';
 
-import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
@@ -77,14 +84,27 @@ const HeaderRight = memo(
   ({ onPaintingChange }: { onPaintingChange: (id: string | null) => void }) => {
     const selectedPaintingId = useSelectedPaintingId();
 
+    // iOS 26's menu enables type-ahead filtering for large submenu trees: it
+    // attaches a hidden UITextField and makes it first responder, summoning the
+    // soft keyboard over the gallery. The field grabs focus on open AND again
+    // each time a submenu is entered, so a one-shot dismiss on open misses it.
+    // Instead, while the menu is open, dismiss the keyboard every time it shows.
+    const menuOpenRef = useRef(false);
+    useEffect(() => {
+      const sub = Keyboard.addListener('keyboardDidShow', () => {
+        if (menuOpenRef.current) {
+          Keyboard.dismiss();
+        }
+      });
+      return () => sub.remove();
+    }, []);
+
     return (
       <DropdownMenu.Root
         onOpenChange={open => {
-          // iOS 26's menu embeds hidden "Forward" text fields for submenu
-          // typeahead; one grabs first responder when the menu opens and
-          // summons the soft keyboard over the gallery. Dismiss it.
+          menuOpenRef.current = open;
           if (open) {
-            requestAnimationFrame(() => Keyboard.dismiss());
+            Keyboard.dismiss();
           }
         }}>
         <DropdownMenu.Trigger>


### PR DESCRIPTION
## Problem

Opening the gallery's painting menu pops the **soft keyboard** over the screen on iOS 26.

## Cause

iOS 26 enables **type-ahead filtering** on large `UIMenu` submenu trees — it attaches a hidden `UITextField` per row (visible in the a11y tree as `AXTextField "Forward"`) and makes one first responder, summoning the keyboard. The field grabs focus on open **and again** each time a submenu is entered, so the previous one-shot `Keyboard.dismiss()` on open missed the later focuses.

## Fix

Dismiss the keyboard on **every** `keyboardDidShow` while the menu is open, via a listener gated by an `isOpen` ref.

## Verification (iPhone 17 simulator)

- Top-level menu open → no keyboard ✅
- Entering a submenu (Renaissance → painters) → no keyboard ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)