### PR TITLE
feat(chessboard): back / replay review actions

### DIFF
--- a/src/animations/chessboard/src/components/game-review-card.tsx
+++ b/src/animations/chessboard/src/components/game-review-card.tsx
@@ -72,7 +72,7 @@ const enter = (delay: number) => () => {
 };
 
 // The post-game review panel: players, accuracy, the move-quality breakdown and
-// the Review / Rematch actions. Each section cascades in via enter(); the
+// the Back / Replay actions. Each section cascades in via enter(); the
 // container's blur-into-focus is driven by the parent through `style`.
 export const GameReviewCard: React.FC<{
   card: ShowOpts;
@@ -174,20 +174,20 @@ export const GameReviewCard: React.FC<{
         <PressableScale
           onPress={() => {
             onHide();
-            card.onReview();
+            card.onBack();
           }}
           style={[styles.btn, styles.btnGhost]}>
-          <Ionicons name="search" size={18} color={theme.text} />
-          <Text style={styles.btnGhostText}>Review</Text>
+          <Ionicons name="arrow-back" size={18} color={theme.text} />
+          <Text style={styles.btnGhostText}>Back</Text>
         </PressableScale>
         <PressableScale
           onPress={() => {
             onHide();
-            card.onRematch();
+            card.onReplay();
           }}
           style={[styles.btn, styles.btnPrimary]}>
-          <Ionicons name="refresh" size={20} color={theme.bg} />
-          <Text style={styles.btnPrimaryText}>Rematch</Text>
+          <Ionicons name="reload" size={20} color={theme.bg} />
+          <Text style={styles.btnPrimaryText}>Replay</Text>
         </PressableScale>
       </Animated.View>
     </Animated.View>

--- a/src/animations/chessboard/src/types.ts
+++ b/src/animations/chessboard/src/types.ts
@@ -26,6 +26,6 @@ export type ShowOpts = {
   oppName: string;
   accuracy: { you: number; opp: number };
   moves: AnnotatedMove[];
-  onRematch: () => void;
-  onReview: () => void;
+  onReplay: () => void;
+  onBack: () => void;
 };

--- a/src/animations/chessboard/src/use-chess-game.ts
+++ b/src/animations/chessboard/src/use-chess-game.ts
@@ -163,11 +163,11 @@ export const useChessGame = ({
         oppName: PLAYERS.b.name,
         accuracy: REVIEW_ACCURACY,
         moves: REVIEW_MOVES,
-        onRematch: rematch,
-        onReview: () => {}, // dismiss to inspect the final board
+        onReplay: playSequence, // re-run the canned game, animating every move
+        onBack: rematch, // reset to a static fresh board, no auto-moves
       });
     },
-    [flipped, pieceSize, show, rematch],
+    [flipped, pieceSize, show, rematch, playSequence],
   );
 
   const onMove = useCallback(

--- a/src/navigation/components/drawer-content.tsx
+++ b/src/navigation/components/drawer-content.tsx
@@ -162,10 +162,10 @@ const styles = StyleSheet.create({
   },
   searchContainer: {
     marginBottom: 0,
-    marginTop: 6,
     // The rounded box reads optically inset vs the sharp title text; pull it
     // a couple px left so its visual left edge lines up with "Demos".
     marginLeft: -2,
+    marginTop: 6,
     position: 'relative',
   },
   searchInput: {

--- a/src/navigation/components/drawer-content.tsx
+++ b/src/navigation/components/drawer-content.tsx
@@ -148,7 +148,8 @@ const styles = StyleSheet.create({
     gap: 8,
     marginBottom: 8,
     marginTop: 6,
-    paddingHorizontal: 20,
+    paddingLeft: 14,
+    paddingRight: 20,
   },
   listContainer: {
     flex: 1,
@@ -156,11 +157,15 @@ const styles = StyleSheet.create({
   },
   listItem: {
     height: LIST_ITEM_HEIGHT,
-    paddingHorizontal: 20,
+    paddingLeft: 16,
+    paddingRight: 20,
   },
   searchContainer: {
     marginBottom: 0,
     marginTop: 6,
+    // The rounded box reads optically inset vs the sharp title text; pull it
+    // a couple px left so its visual left edge lines up with "Demos".
+    marginLeft: -2,
     position: 'relative',
   },
   searchInput: {


### PR DESCRIPTION
## What

Reworks the chessboard demo's post-game review card actions, plus a small drawer padding tweak.

### Chessboard review card
- **Replay** (primary, `reload` icon) — re-runs the canned game, animating every move again (`playSequence`).
- **Back** (ghost, `arrow-back` icon) — resets to a static fresh starting board, no auto-moves (`rematch`).

Renamed `ShowOpts.onRematch` → `onReplay` and `onReview` → `onBack`.

Previously: **Review** (dismiss, did nothing visible) + **Rematch** (static reset).

### Drawer (separate commit)
Pull search box + list-item left edges a couple px left so they optically align with the "Demos" title.

## Verified
On iPhone 17 (iOS 26):
- Back → static fresh board, clocks 3:00, no moves.
- Replay → full game re-animates to mate, card re-shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)